### PR TITLE
Allow salt-free passwords

### DIFF
--- a/classes/kohana/auth.php
+++ b/classes/kohana/auth.php
@@ -220,8 +220,11 @@ abstract class Kohana_Auth {
 
 		foreach ($this->_config['salt_pattern'] as $i => $offset)
 		{
-			// Find salt characters, take a good long look...
-			$salt .= substr($password, $offset + $i, 1);
+			if ($offset != NULL)
+			{
+				// Find salt characters, take a good long look...
+				$salt .= substr($password, $offset + $i, 1);
+			}
 		}
 
 		return $salt;


### PR DESCRIPTION
If the salt_pattern is null or an empty string, find_salt will now return an empty string instead of returning the first character of the password as the salt.
