### PR TITLE
Allowing injection of Auth instance for unit testing mocking purposes

### DIFF
--- a/classes/kohana/auth.php
+++ b/classes/kohana/auth.php
@@ -18,9 +18,13 @@ abstract class Kohana_Auth {
 	 *
 	 * @return Auth
 	 */
-	public static function instance()
+	public static function instance($instance=NULL)
 	{
-		if ( ! isset(Auth::$_instance))
+		if ( $instance )
+		{
+			Auth::$_instance = $instance;
+		}
+		else if ( ! isset(Auth::$_instance))
 		{
 			// Load the configuration for this type
 			$config = Kohana::config('auth');


### PR DESCRIPTION
Change the instance method to allow an optional object to be passed to set the instance for subsequent requests. Needed to allow use of a mock Auth object in unit tests.
