### PR TITLE
Add composer.json to support installing with composer. Fixes #4776

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+	"name":        "kohana/auth",
+	"type":        "kohana-module",
+	"description": "The official Kohana auth module",
+	"homepage":    "http://kohanaframework.org",
+	"license":     "BSD-3-Clause",
+	"keywords":    ["kohana", "framework", "authentication"],
+	"authors": [
+		{
+			"name":     "Kohana Team",
+			"email":    "team@kohanaframework.org",
+			"homepage": "http://kohanaframework.org/team",
+			"role":     "developer"
+		}
+	],
+	"support": {
+		"issues":   "http://dev.kohanaframework.org",
+		"forum":    "http://forum.kohanaframework.org",
+		"irc":      "irc://irc.freenode.net/kohana",
+		"source":   "http://github.com/kohana/core"
+	},
+	"require": {
+		"composer/installers": "~1.0",
+		"kohana/core":         ">=3.3",
+		"php":                 ">=5.3.3"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-3.3/dev":  "3.3.x-dev",
+			"dev-3.4/dev":  "3.4.x-dev"
+		}
+	}
+}


### PR DESCRIPTION
As discussed in http://dev.kohanaframework.org/issues/4776, adds a composer.json to the auth module to simplify using composer to manage Kohana module dependencies.
