### PR TITLE
Configure standalone travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ Icon?
 code_coverage
 *~
 *.swp
+composer.lock
+vendor/*
+koharness_bootstrap.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - composer install --prefer-dist
+  - vendor/bin/koharness
+
+script:
+  - cd /tmp/koharness && ./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap.php modules/unittest/tests.php
+
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#kohana"
+    template:
+      - "%{repository}/%{branch} (%{commit}) - %{author}: %{message}"
+      - "Build details: %{build_url}"
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,4 @@ script:
   - cd /tmp/koharness && ./vendor/bin/phpunit --bootstrap=modules/unittest/bootstrap.php modules/unittest/tests.php
 
 notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#kohana"
-    template:
-      - "%{repository}/%{branch} (%{commit}) - %{author}: %{message}"
-      - "Build details: %{build_url}"
   email: false

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,18 @@
 		"kohana/core":         ">=3.3",
 		"php":                 ">=5.3.3"
 	},
+	"require-dev": {
+		"kohana/core":         "3.3.*@dev",
+		"kohana/unittest":     "3.3.*@dev",
+		"kohana/koharness":    "*@dev"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-3.3/develop": "3.3.x-dev",
 			"dev-3.4/develop": "3.4.x-dev"
+		},
+		"installer-paths": {
+			"vendor/{$vendor}/{$name}": ["type:kohana-module"]
 		}
 	}
 }

--- a/koharness.php
+++ b/koharness.php
@@ -1,0 +1,8 @@
+<?php
+// Configuration for koharness - builds a standalone skeleton Kohana app for running unit tests
+return array(
+	'modules' => array(
+		'auth'     => __DIR__,
+		'unittest' => __DIR__ . '/vendor/kohana/unittest'
+	),
+);


### PR DESCRIPTION
Adds and configures kohana/koharness to build a skeleton Kohana
application and then uses that environment to run the unit tests
on travis (and locally, if required).

Continues kohana/kohana#50
