### PR TITLE
PHP native session  & Linux compatibility when using ORM Auth

### DIFF
--- a/classes/Kohana/Auth.php
+++ b/classes/Kohana/Auth.php
@@ -73,7 +73,17 @@ abstract class Kohana_Auth {
 	 */
 	public function get_user($default = NULL)
 	{
-		return $this->_session->get($this->_config['session_key'], $default);
+		$user=$this->_session->get($this->_config['session_key'], $default);
+		if(is_array($user) && array_key_exists('id',$user) && $this->_config['driver']=='orm'){
+			$user=ORM::factory('User',$user['id']);
+			if($user->loaded()){
+				return $user;
+			} else {
+				return $default;
+			}
+		} else {
+			return $this->_session->get($this->_config['session_key'], $default);
+		}
 	}
 
 	/**
@@ -159,6 +169,10 @@ abstract class Kohana_Auth {
 
 	protected function complete_login($user)
 	{
+		// Make sure our user is PHP native session safe
+		if($this->_config['driver']=='orm'){
+			$user=$user->as_array();
+		}		
 		// Regenerate session_id
 		$this->_session->regenerate();
 

--- a/classes/Kohana/Auth.php
+++ b/classes/Kohana/Auth.php
@@ -31,6 +31,10 @@ abstract class Kohana_Auth {
 			}
 
 			// Set the session class name
+			// Make sure our case matches for Linux
+			if($type=='orm')
+				$type=strtoupper($type);
+			
 			$class = 'Auth_'.ucfirst($type);
 
 			// Create a new session instance


### PR DESCRIPTION
PHP native sessions will choke when storing ORM objects with a high number of relationships.  Adding functions to convert ORM user objects to and from arrays.

ORM auth on Linux throws errors on the class case. Update to fix.
